### PR TITLE
yum-config-manager --enable remi-php70

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,6 +5,7 @@ RUN yum install -y epel-release \
         http://rpms.remirepo.net/enterprise/remi-release-7.rpm  \
         yum-utils && \
     yum-config-manager --enable remi-php70 && \
+    yum update -y && \
     yum install -y \
         php-bcmath \
         php-cli \


### PR DESCRIPTION
This is the solution to issue  #5 

as discovered in 

https://github.com/contentacms/contenta_docker/issues/5#issuecomment-356860085

The dockerfile does not function as intended -- at the end the container is on php5.4.16

drupal8.4 and above bump the php version and this is causing problems

to properly complete the transition to php70 the command must be followed by

a yum update command

[ see https://blog.remirepo.net/post/2017/09/29/PHP-version-7.0.24-and-7.1.10 ]