### PR TITLE
The nginx parent image doesn't exist

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazeeio/centos7-nginx:1.10
+FROM amazeeio/nginx:1.9
 
 COPY conf/drupal.conf /etc/nginx/sites/drupal.conf
 


### PR DESCRIPTION
this should fix https://github.com/contentacms/contenta_docker/issues/35